### PR TITLE
Added testing on /auth endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "_migrate": "sequelize db:migrate",
         "_seed": "sequelize db:seed:all",
         "db_complete": "node create_db && sequelize db:migrate && sequelize db:seed:all",
+        "test": "jest --watchAll --detectOpenHandles ",
         "start": "node ./bin/www"
     },
     "dependencies": {
@@ -29,7 +30,9 @@
         "sequelize": "^6.3.5"
     },
     "devDependencies": {
+        "jest": "^28.1.3",
         "nodemon": "^2.0.16",
-        "sequelize-cli": "^6.4.1"
+        "sequelize-cli": "^6.4.1",
+        "supertest": "^6.2.4"
     }
 }

--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -1,58 +1,60 @@
-const authService = require('../services/auth-service')
-const userService = require('../services/user-service')
-const { validationResult } = require('express-validator')
-const { RegisterValidationError } = require('../errors/auth-errors')
+const authService = require("../services/auth-service");
+const userService = require("../services/user-service");
+const { validationResult } = require("express-validator");
+const { RegisterValidationError } = require("../errors/auth-errors");
+
 const login = async (req, res, next) => {
-    try {
-        const data = await authService.login(req.body)
-        res.json({
-            user: data.user,
-            accessToken: data.accessToken
-        })
-    } catch (err) {
-       next(err)
+  try {
+    const errorsLogin = validationResult(req);
+    if (!errorsLogin.isEmpty()) {
+      res.status(400).json(errorsLogin);
+    } else {
+      const data = await authService.login(req.body);
+      res.json({
+        user: data.user,
+        accessToken: data.accessToken,
+      });
     }
-}
+  } catch (err) {
+    next(err);
+  }
+};
 
 const register = async (req, res, next) => {
-    try {
-        const { body } = req;
-        const errorsRegister = validationResult(req);
-        if (!errorsRegister.isEmpty()) {
-            //406 no Acceptable
-           throw new RegisterValidationError(errorsRegister.mapped()) //devuelvo los errores al front por si los necesita
-        } else {
-
-            const data = await authService.register({ ...body })
-            res.json({
-                user: data.user,
-                accessToken: data.accessToken
-            })
-        }
-
-    } catch (err) {
-      
-        next(err)
-
+  try {
+    const { body } = req;
+    const errorsRegister = validationResult(req);
+    if (!errorsRegister.isEmpty()) {
+      //406 no Acceptable
+      throw new RegisterValidationError(errorsRegister.mapped()); //devuelvo los errores al front por si los necesita
+    } else {
+      const data = await authService.register({ ...body });
+      res.json({
+        user: data.user,
+        accessToken: data.accessToken,
+      });
     }
-}
+  } catch (err) {
+    next(err);
+  }
+};
 
 const getProfile = async (req, res, next) => {
-    const authHeader = req.headers['authorization']
-    const token = authHeader && authHeader.split(' ')[1]
-    
-    const decoded = jwt.decode(token)
-     const id = decoded.id
-     try {   
-        const results = await authService.getMyProfile(id);
-        res.status(200).json(results);
-      } catch (err) {
-              next(err)
-            }
+  const authHeader = req.headers["authorization"];
+  const token = authHeader && authHeader.split(" ")[1];
+
+  const decoded = jwt.decode(token);
+  const id = decoded.id;
+  try {
+    const results = await authService.getMyProfile(id);
+    res.status(200).json(results);
+  } catch (err) {
+    next(err);
   }
+};
 
 module.exports = {
-    register,
-    login,
-    getProfile
-}
+  register,
+  login,
+  getProfile,
+};

--- a/src/middlewares/validations/ValidateLogin.js
+++ b/src/middlewares/validations/ValidateLogin.js
@@ -1,0 +1,9 @@
+const { body } = require('express-validator')
+
+
+module.exports = [
+    body('email')
+        .notEmpty().withMessage('Debe enviar un email para logearse')
+        .isEmail().withMessage('El email enviado no es una direccion de email valida'),
+    body('password').notEmpty().withMessage('Debe completar el campo contraseña')
+]

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,14 +1,11 @@
 const express = require("express");
 const router = express.Router();
-const authController = require('../controllers/auth-controller')
-
-
+const authController = require('../controllers/auth-controller');
+const ValidateLogin = require("../middlewares/validations/ValidateLogin");
 const ValidationOfTheRegistrationForm = require('../middlewares/validations/ValidationOfTheRegistrationForm')
 
-router.post("/login", authController.login)
+router.post("/login", ValidateLogin, authController.login)
 
 router.post("/register", ValidationOfTheRegistrationForm, authController.register)
-
-
 
 module.exports = router

--- a/src/services/auth-service.js
+++ b/src/services/auth-service.js
@@ -11,7 +11,7 @@ const login = async (body) => {
     const user = await userService.getUserByEmail(body.email)
     if (bcrypt.compareSync(body.password, user.password)) {
         const accessToken = await generateAccessToken(user)
-        delete await user.password
+        delete user.dataValues.password
         return { accessToken , user }
     } else {
         throw new WrongPasswordError()

--- a/src/test/auth.test.js
+++ b/src/test/auth.test.js
@@ -1,0 +1,167 @@
+const request = require("supertest");
+const app = require("../app");
+const jwt = require("jsonwebtoken");
+const { User } = require("../models");
+require("dotenv").config();
+
+beforeEach(async () => {
+  //Here I'm deleting the test email so it can be posted at the register of a user, otherwise, it will appear as an already taken email
+  await User.destroy({ where: { email: "admintest@gmail.com" } });
+});
+
+describe("POST /auth/login", () => {
+  test("should respond with a 200 status code and a json with user info plus accesstoken", async () => {
+    const response = await request(app)
+      .post("/auth/login")
+      .send({ email: "admin@gmail.com", password: "admin1234" });
+    expect(response.headers["content-type"]).toEqual(
+      expect.stringContaining("json")
+    );
+    //Making sure a password is not beeing sent
+    expect(response.body.user.password).toBe(undefined);
+    expect(response.body.accessToken).not.toBe(undefined);
+    const { dataValues } = jwt.verify(
+      response.body.accessToken,
+      process.env.SECRET_JWT_SEED
+    );
+    //At the following line, I'm checking if the access Token sent matches the user id to ensure token integrity and make sure it has the correct user data
+
+    expect(response.body.user.id).toEqual(dataValues.id);
+    expect(response.body.user).toEqual(
+      expect.objectContaining({
+        id: expect.any(Number),
+        roleId: expect.any(Number),
+        lastName: expect.any(String),
+        firstName: expect.any(String),
+        email: expect.any(String),
+      })
+    );
+    expect(response.statusCode).toBe(200);
+  });
+
+  test("should respond with a 400 if fields are not sent or are invalid", async () => {
+    const bodyData = [
+      { email: "admingmail.com" },
+      { email: "admin@gmail.com" },
+      { password: "admin1234" },
+      { password: "" },
+      {},
+    ];
+    for (const body of bodyData) {
+      const response = await request(app).post("/auth/login").send(body);
+      expect(response.headers["content-type"]).toEqual(
+        expect.stringContaining("json")
+      );
+      expect(response.statusCode).toBe(400);
+    }
+  });
+
+  test("should respond with a 400 and an error if password is incorrect", async () => {
+    const response = await request(app)
+      .post("/auth/login")
+      .send({ email: "admin@gmail.com", password: "admin123" });
+    expect(response.headers["content-type"]).toEqual(
+      expect.stringContaining("json")
+    );
+    expect(response.body["name"]).toEqual(
+      expect.stringContaining("WrongPassword")
+    );
+    expect(response.statusCode).toBe(400);
+  });
+
+  test("should respond with a 400 and an error if email does not exists ", async () => {
+    const response = await request(app)
+      .post("/auth/login")
+      .send({ email: "adminnon@gmail.com", password: "admin1234" });
+    expect(response.headers["content-type"]).toEqual(
+      expect.stringContaining("json")
+    );
+    expect(response.body["name"]).toEqual(
+      expect.stringContaining("UserNotFoundError")
+    );
+    expect(response.statusCode).toBe(400);
+  });
+});
+
+describe("POST /auth/register", () => {
+  test("should respond with a 200 status code and a json with user info plus accesstoken", async () => {
+    const response = await request(app).post("/auth/register").send({
+      firstName: "Rodri",
+      lastName: "Valdi",
+      email: "admintest@gmail.com",
+      password: "admin1234",
+    });
+    expect(response.headers["content-type"]).toEqual(
+      expect.stringContaining("json")
+    );
+    //Making sure a password is not beeing sent
+    expect(response.body.user.password).toBe(undefined);
+    expect(response.body.accessToken).not.toBe(undefined);
+    const { dataValues } = jwt.verify(
+      response.body.accessToken,
+      process.env.SECRET_JWT_SEED
+    );
+    expect(response.body.user.id).toEqual(dataValues.id);
+    expect(response.body.user).toEqual(
+      expect.objectContaining({
+        id: expect.any(Number),
+        roleId: expect.any(Number),
+        lastName: expect.any(String),
+        firstName: expect.any(String),
+        email: expect.any(String),
+      })
+    );
+    expect(response.statusCode).toBe(200);
+  });
+
+  test("should respond with a 406 and an error if there are missing or wrong fields", async () => {
+
+    //Sending multiple wrong objects to ensure errors are sent
+    const bodyData = [
+      { email: "admingmail.com" },
+      { email: "" },
+      {
+        firstName: "Rodri",
+        lastName: "Valdi",
+        email: "admigmail.com",
+        password: "admi",
+      },
+      { email: "admin@gmail.com" },
+      { password: "admin1234" },
+      { password: "" },
+      {},
+    ];
+
+    for (const body of bodyData) {
+      const response = await request(app).post("/auth/register").send(body);
+      expect(response.headers["content-type"]).toEqual(
+        expect.stringContaining("json")
+      );
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          name: "RegisterValidationError",
+          validationErrors: expect.any(Object),
+          message: "Error de validacion",
+        })
+      );
+      expect(response.statusCode).toBe(406);
+    }
+  });
+
+  test("should respond with a 400 status code when an email thats already taken is sent", async () => {
+    const response = await request(app).post("/auth/register").send({
+      firstName: "Rodri",
+      lastName: "Valdi",
+      email: "admin@gmail.com",
+      password: "admin1234",
+    });
+    expect(response.headers["content-type"]).toEqual(
+      expect.stringContaining("json")
+    );
+    expect(response.body["name"]).toEqual(
+      expect.stringContaining("CredentialsTakenError")
+    );
+
+    expect(response.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Issue ticket link
https://alkemy-labs.atlassian.net/browse/OT221-119

## Summary
-Added testing to the /auth endpoints
-Now the server is able to test the different outcomes when trying to post to /auth/register and /auth /login, it will check error and success responses to be as desire.

## Evidence
![2022-07-29 13_20_27-OT221-server - Visual Studio Code](https://user-images.githubusercontent.com/79865376/181803404-1e392769-9079-4fe8-b561-d1b2cc51d93f.png)

